### PR TITLE
Cleanup-Refactor

### DIFF
--- a/src/IxMilia.Converters.Test/DxfToSvgTests.cs
+++ b/src/IxMilia.Converters.Test/DxfToSvgTests.cs
@@ -424,7 +424,7 @@ namespace IxMilia.Converters.Test
         public void EnsureValidShapeAsBareSvg()
         {
             // svg starts with 5 levels of `g`
-            var element = new DxfToSvgConverter().Convert(new DxfFile(), new DxfToSvgConverterOptions(new ConverterDxfRect(), new ConverterSvgRect()));
+            var element = new DxfToSvgConverter().Convert(new DxfFile(), new DxfToSvgConverterOptions(new ConverterDxfRect(0, 0, 0, 0), new ConverterSvgRect(0, 0)));
             Assert.Equal("svg", element.Name.LocalName);
             var g = element.Elements().Single();
             for (int i = 0; i < 5; i++)
@@ -437,7 +437,7 @@ namespace IxMilia.Converters.Test
         [Fact]
         public void EnsureValidShapeAsDiv()
         {
-            var element = new DxfToSvgConverter().Convert(new DxfFile(), new DxfToSvgConverterOptions(new ConverterDxfRect(), new ConverterSvgRect(), svgId: "test-id"));
+            var element = new DxfToSvgConverter().Convert(new DxfFile(), new DxfToSvgConverterOptions(new ConverterDxfRect(0, 0, 0, 0), new ConverterSvgRect(0, 0), svgId: "test-id"));
             Assert.Equal("div", element.Name.LocalName);
             Assert.Equal("test-id", element.Attribute("id").Value);
             var children = element.Elements().ToList();

--- a/src/IxMilia.Converters.Test/DxfToSvgTests.cs
+++ b/src/IxMilia.Converters.Test/DxfToSvgTests.cs
@@ -424,7 +424,7 @@ namespace IxMilia.Converters.Test
         public void EnsureValidShapeAsBareSvg()
         {
             // svg starts with 5 levels of `g`
-            var element = new DxfToSvgConverter().Convert(new DxfFile(), new DxfToSvgConverterOptions(new ConverterDxfRect(0, 0, 0, 0), new ConverterSvgRect(0, 0)));
+            var element = new DxfToSvgConverter().Convert(new DxfFile(), new DxfToSvgConverterOptions(new ConverterDxfRect(), new ConverterSvgRect()));
             Assert.Equal("svg", element.Name.LocalName);
             var g = element.Elements().Single();
             for (int i = 0; i < 5; i++)
@@ -437,7 +437,7 @@ namespace IxMilia.Converters.Test
         [Fact]
         public void EnsureValidShapeAsDiv()
         {
-            var element = new DxfToSvgConverter().Convert(new DxfFile(), new DxfToSvgConverterOptions(new ConverterDxfRect(0, 0, 0, 0), new ConverterSvgRect(0, 0), svgId: "test-id"));
+            var element = new DxfToSvgConverter().Convert(new DxfFile(), new DxfToSvgConverterOptions(new ConverterDxfRect(), new ConverterSvgRect(), svgId: "test-id"));
             Assert.Equal("div", element.Name.LocalName);
             Assert.Equal("test-id", element.Attribute("id").Value);
             var children = element.Elements().ToList();

--- a/src/IxMilia.Converters/ConverterDxfRect.cs
+++ b/src/IxMilia.Converters/ConverterDxfRect.cs
@@ -12,6 +12,14 @@ namespace IxMilia.Converters
         public double Width => this.Right - this.Left;
         public double Height => this.Top - this.Bottom;
 
+        public ConverterDxfRect()
+        {
+            Left = 0;
+            Right = 0;
+            Bottom = 0;
+            Top = 0;
+        }
+
         public ConverterDxfRect(double left, double right, double bottom, double top)
         {
             if (left >= right)

--- a/src/IxMilia.Converters/ConverterDxfRect.cs
+++ b/src/IxMilia.Converters/ConverterDxfRect.cs
@@ -3,7 +3,7 @@ using IxMilia.Dxf;
 
 namespace IxMilia.Converters
 {
-    public struct ConverterDxfRect
+    public class ConverterDxfRect
     {
         public double Left { get; }
         public double Right { get; }

--- a/src/IxMilia.Converters/ConverterPdfRect.cs
+++ b/src/IxMilia.Converters/ConverterPdfRect.cs
@@ -39,6 +39,14 @@ namespace IxMilia.Converters
         public PdfMeasurement Width => new PdfMeasurement(this.Right.AsPoints() - this.Left.AsPoints(), PdfMeasurementType.Point);
         public PdfMeasurement Height => new PdfMeasurement(this.Top.AsPoints() - this.Bottom.AsPoints(), PdfMeasurementType.Point);
 
+        public ConverterPdfRect()
+        {
+            Left = PdfMeasurement.Zero;
+            Right = PdfMeasurement.Zero;
+            Bottom = PdfMeasurement.Zero;
+            Top = PdfMeasurement.Zero;
+        }
+
         public ConverterPdfRect(PdfMeasurement left, PdfMeasurement right, PdfMeasurement bottom, PdfMeasurement top)
         {
             if (left.AsPoints() >= right.AsPoints())

--- a/src/IxMilia.Converters/ConverterSvgRect.cs
+++ b/src/IxMilia.Converters/ConverterSvgRect.cs
@@ -2,13 +2,13 @@
 {
     public struct ConverterSvgRect
     {
-        public double ElementWidth { get; }
-        public double ElementHeight { get; }
+        public double Width { get; }
+        public double Height { get; }
 
-        public ConverterSvgRect(double elementWidth, double elementHeight)
+        public ConverterSvgRect(double width, double height)
         {
-            ElementWidth = elementWidth;
-            ElementHeight = elementHeight;
+            Width = width;
+            Height = height;
         }
     }
 }

--- a/src/IxMilia.Converters/ConverterSvgRect.cs
+++ b/src/IxMilia.Converters/ConverterSvgRect.cs
@@ -5,6 +5,12 @@
         public double Width { get; }
         public double Height { get; }
 
+        public ConverterSvgRect()
+        {
+            Width = 0;
+            Height = 0;
+        }
+
         public ConverterSvgRect(double width, double height)
         {
             Width = width;

--- a/src/IxMilia.Converters/ConverterSvgRect.cs
+++ b/src/IxMilia.Converters/ConverterSvgRect.cs
@@ -1,6 +1,6 @@
 ﻿namespace IxMilia.Converters
 {
-    public struct ConverterSvgRect
+    public class ConverterSvgRect
     {
         public double Width { get; }
         public double Height { get; }

--- a/src/IxMilia.Converters/DoubleExtensions.cs
+++ b/src/IxMilia.Converters/DoubleExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace IxMilia.Converters
+{
+    public static class DoubleExtensions
+    {
+        public static bool IsCloseTo(this double a, double b)
+        {
+            return Math.Abs(a - b) < 1.0e-10;
+        }
+    }
+}

--- a/src/IxMilia.Converters/DxfToPdfConverter.cs
+++ b/src/IxMilia.Converters/DxfToPdfConverter.cs
@@ -13,25 +13,25 @@ namespace IxMilia.Converters
         public PdfMeasurement PageWidth { get; }
         public PdfMeasurement PageHeight { get; }
         public double Scale { get; }
-        public ConverterDxfRect? DxfSource { get; }
-        public ConverterPdfRect PdfDestination { get; }
+        public ConverterDxfRect DxfRect { get; }
+        public ConverterPdfRect PdfRect { get; }
 
         public DxfToPdfConverterOptions(PdfMeasurement pageWidth, PdfMeasurement pageHeight, double scale)
         {
             PageWidth = pageWidth;
             PageHeight = pageHeight;
             Scale = scale;
-            this.DxfSource = null;
-            this.PdfDestination = null;
+            this.DxfRect = null;
+            this.PdfRect = null;
         }
 
-        public DxfToPdfConverterOptions(PdfMeasurement pageWidth, PdfMeasurement pageHeight, ConverterDxfRect? dxfSource, ConverterPdfRect pdfDestination)
+        public DxfToPdfConverterOptions(PdfMeasurement pageWidth, PdfMeasurement pageHeight, ConverterDxfRect dxfSource, ConverterPdfRect pdfDestination)
         {
             PageWidth = pageWidth;
             PageHeight = pageHeight;
             Scale = 1d;
-            this.DxfSource = dxfSource ?? throw new ArgumentNullException(nameof(dxfSource));
-            this.PdfDestination = pdfDestination ?? throw new ArgumentNullException(nameof(pdfDestination));
+            this.DxfRect = dxfSource ?? throw new ArgumentNullException(nameof(dxfSource));
+            this.PdfRect = pdfDestination ?? throw new ArgumentNullException(nameof(pdfDestination));
         }
     }
 
@@ -78,14 +78,14 @@ namespace IxMilia.Converters
         private static void CreateTransformations(DxfViewPort viewPort, DxfToPdfConverterOptions options,
             out Matrix4 scale, out Matrix4 affine)
         {
-            if (options.DxfSource != null && options.PdfDestination != null)
+            if (options.DxfRect != null && options.PdfRect != null)
             {
                 // user supplied source and destination rectangles, no trouble with units
-                var dxfSource = options.DxfSource.GetValueOrDefault();
-                double pdfOffsetX = options.PdfDestination.Left.AsPoints();
-                double pdfOffsetY = options.PdfDestination.Bottom.AsPoints();
-                double scaleX = options.PdfDestination.Width.AsPoints() / dxfSource.Width;
-                double scaleY = options.PdfDestination.Height.AsPoints() / dxfSource.Height;
+                var dxfSource = options.DxfRect.GetValueOrDefault();
+                double pdfOffsetX = options.PdfRect.Left.AsPoints();
+                double pdfOffsetY = options.PdfRect.Bottom.AsPoints();
+                double scaleX = options.PdfRect.Width.AsPoints() / dxfSource.Width;
+                double scaleY = options.PdfRect.Height.AsPoints() / dxfSource.Height;
                 double dxfOffsetX = dxfSource.Left;
                 double dxfOffsetY = dxfSource.Bottom;
                 scale = Matrix4.CreateScale(scaleX, scaleY, 0.0);

--- a/src/IxMilia.Converters/DxfToPdfConverter.cs
+++ b/src/IxMilia.Converters/DxfToPdfConverter.cs
@@ -248,7 +248,7 @@ namespace IxMilia.Converters
                 .ToPdfPoint(PdfMeasurementType.Point);
             var p2 = affine.Transform(new Vector(next.X, next.Y, 0))
                 .ToPdfPoint(PdfMeasurementType.Point);
-            if (vertex.Bulge.Equals(0.0))
+            if (vertex.Bulge.IsCloseTo(0.0))
             {
                 return new PdfLine(p1, p2, pdfStreamState);
             }
@@ -256,7 +256,7 @@ namespace IxMilia.Converters
             double dx = next.X - vertex.X;
             double dy = next.Y - vertex.Y;
             double length = Math.Sqrt(dx * dx + dy * dy);
-            if (length <= 1e-10)
+            if (length.IsCloseTo(1e-10))
             {
                 // segment is very short, avoid numerical problems
                 return new PdfLine(p1, p2, pdfStreamState);

--- a/src/IxMilia.Converters/DxfToPdfConverter.cs
+++ b/src/IxMilia.Converters/DxfToPdfConverter.cs
@@ -81,13 +81,13 @@ namespace IxMilia.Converters
             if (options.DxfRect != null && options.PdfRect != null)
             {
                 // user supplied source and destination rectangles, no trouble with units
-                var dxfSource = options.DxfRect.GetValueOrDefault();
+                var dxfRect = options.DxfRect;
                 double pdfOffsetX = options.PdfRect.Left.AsPoints();
                 double pdfOffsetY = options.PdfRect.Bottom.AsPoints();
-                double scaleX = options.PdfRect.Width.AsPoints() / dxfSource.Width;
-                double scaleY = options.PdfRect.Height.AsPoints() / dxfSource.Height;
-                double dxfOffsetX = dxfSource.Left;
-                double dxfOffsetY = dxfSource.Bottom;
+                double scaleX = options.PdfRect.Width.AsPoints() / dxfRect.Width;
+                double scaleY = options.PdfRect.Height.AsPoints() / dxfRect.Height;
+                double dxfOffsetX = dxfRect.Left;
+                double dxfOffsetY = dxfRect.Bottom;
                 scale = Matrix4.CreateScale(scaleX, scaleY, 0.0);
                 affine = Matrix4.CreateTranslate(+pdfOffsetX, +pdfOffsetY, 0.0)
                     * scale

--- a/src/IxMilia.Converters/DxfToSvgConverter.cs
+++ b/src/IxMilia.Converters/DxfToSvgConverter.cs
@@ -483,16 +483,8 @@ namespace IxMilia.Converters
         {
             if (color.IsIndex)
             {
-                var stroke = element.Attribute("stroke");
                 var colorString = color.ToRGBString();
-                if (stroke == null)
-                {
-                    element.Add(new XAttribute("stroke", colorString));
-                }
-                else
-                {
-                    stroke.Value = colorString;
-                }
+                element.SetAttributeValue("stroke", colorString);
             }
 
             return element;

--- a/src/IxMilia.Converters/DxfToSvgConverter.cs
+++ b/src/IxMilia.Converters/DxfToSvgConverter.cs
@@ -81,12 +81,12 @@ namespace IxMilia.Converters
                                 new XAttribute("transform", $"translate({(-options.DxfRect.Left).ToDisplayString()} {(-options.DxfRect.Bottom).ToDisplayString()})"),
                                 world)))));
 
-            var layerNames = file.Layers.OrderBy(l => l.Name).Select(l => l.Name).ToArray();
-            root = TransformToHtmlDiv(root, options.SvgId, layerNames, -options.DxfSource.Left, -options.DxfSource.Bottom, scale, scale);
+            var layerNames = file.Layers.OrderBy(l => l.Name).Select(l => l.Name);
+            root = TransformToHtmlDiv(root, options.SvgId, layerNames, -options.DxfRect.Left, -options.DxfRect.Bottom, scale, scale);
             return root;
         }
 
-        private static XElement TransformToHtmlDiv(XElement svg, string svgId, string[] layerNames, double defaultXTranslate, double defaultYTranslate, double defaultXScale, double defaultYScale)
+        private static XElement TransformToHtmlDiv(XElement svg, string svgId, IEnumerable<string> layerNames, double defaultXTranslate, double defaultYTranslate, double defaultXScale, double defaultYScale)
         {
             if (string.IsNullOrWhiteSpace(svgId))
             {
@@ -131,7 +131,7 @@ namespace IxMilia.Converters
             return div;
         }
 
-        private static string GetJavascriptControls(string svgId, string[] layerNames, double defaultXTranslate, double defaultYTranslate, double defaultXScale, double defaultYScale)
+        private static string GetJavascriptControls(string svgId, IEnumerable<string> layerNames, double defaultXTranslate, double defaultYTranslate, double defaultXScale, double defaultYScale)
         {
             var assembly = typeof(DxfToSvgConverter).GetTypeInfo().Assembly;
             using (var jsStream = assembly.GetManifestResourceStream("IxMilia.Converters.SvgJavascriptControls.js"))

--- a/src/IxMilia.Converters/DxfToSvgConverter.cs
+++ b/src/IxMilia.Converters/DxfToSvgConverter.cs
@@ -267,7 +267,7 @@ namespace IxMilia.Converters
         public static XElement ToXElement(this DxfEllipse ellipse)
         {
             XElement baseShape;
-            if (IsCloseTo(ellipse.StartParameter, 0.0) && IsCloseTo(ellipse.EndParameter, Math.PI * 2.0))
+            if (ellipse.StartParameter.IsCloseTo(0.0) && ellipse.EndParameter.IsCloseTo(Math.PI * 2.0))
             {
                 baseShape = new XElement(DxfToSvgConverter.Xmlns + "ellipse",
                     new XAttribute("cx", ellipse.Center.X.ToDisplayString()),
@@ -373,7 +373,7 @@ namespace IxMilia.Converters
             var dx = nextX - lastX;
             var dy = nextY - lastY;
             var dist = Math.Sqrt(dx * dx + dy * dy);
-            if (lastBulge == 0.0 || IsCloseTo(dist, 1.0e-10))
+            if (lastBulge.IsCloseTo(0.0) || dist.IsCloseTo(1.0e-10))
             {
                 // line or a really short arc
                 return new SvgLineToPath(nextX, nextY);
@@ -508,11 +508,6 @@ namespace IxMilia.Converters
         {
             element.Add(new XAttribute("vector-effect", "non-scaling-stroke"));
             return element;
-        }
-
-        private static bool IsCloseTo(double a, double b)
-        {
-            return Math.Abs(a - b) < 1.0e-10;
         }
     }
 }

--- a/src/IxMilia.Converters/DxfToSvgConverter.cs
+++ b/src/IxMilia.Converters/DxfToSvgConverter.cs
@@ -13,14 +13,14 @@ namespace IxMilia.Converters
 {
     public struct DxfToSvgConverterOptions
     {
-        public ConverterDxfRect DxfSource { get; }
-        public ConverterSvgRect SvgDestination { get; }
+        public ConverterDxfRect DxfRect { get; }
+        public ConverterSvgRect SvgRect { get; }
         public string SvgId { get; }
 
-        public DxfToSvgConverterOptions(ConverterDxfRect dxfSource, ConverterSvgRect svgDestination, string svgId = null)
+        public DxfToSvgConverterOptions(ConverterDxfRect dxfRect, ConverterSvgRect svgRect, string svgId = null)
         {
-            DxfSource = dxfSource;
-            SvgDestination = svgDestination;
+            DxfRect = dxfRect;
+            SvgRect = svgRect;
             SvgId = svgId;
         }
     }
@@ -53,21 +53,21 @@ namespace IxMilia.Converters
                 world.Add(g);
             }
 
-            var dxfar = options.DxfSource.Width / options.DxfSource.Height;
-            var svgar = options.SvgDestination.ElementWidth / options.SvgDestination.ElementHeight;
-            var scale = svgar < dxfar
-                ? options.SvgDestination.ElementWidth / options.DxfSource.Width
-                : options.SvgDestination.ElementHeight / options.DxfSource.Height;
+            var dxfAspectRatio = options.DxfRect.Width / options.DxfRect.Height;
+            var svgAspectRatio = options.SvgRect.Width / options.SvgRect.Height;
+            var scale = svgAspectRatio < dxfAspectRatio
+                ? options.SvgRect.Width / options.DxfRect.Width
+                : options.SvgRect.Height / options.DxfRect.Height;
 
             var root = new XElement(Xmlns + "svg",
-                new XAttribute("width", options.SvgDestination.ElementWidth.ToDisplayString()),
-                new XAttribute("height", options.SvgDestination.ElementHeight.ToDisplayString()),
-                new XAttribute("viewBox", $"0 0 {options.SvgDestination.ElementWidth.ToDisplayString()} {options.SvgDestination.ElementHeight.ToDisplayString()}"),
+                new XAttribute("width", options.SvgRect.Width.ToDisplayString()),
+                new XAttribute("height", options.SvgRect.Height.ToDisplayString()),
+                new XAttribute("viewBox", $"0 0 {options.SvgRect.Width.ToDisplayString()} {options.SvgRect.Height.ToDisplayString()}"),
                 new XAttribute("version", "1.1"),
                 new XAttribute("class", "dxf-drawing"),
                 new XComment(" this group corrects for the y-axis going in different directions "),
                 new XElement(Xmlns + "g",
-                    new XAttribute("transform", $"translate(0 {options.SvgDestination.ElementHeight.ToDisplayString()}) scale(1 -1)"),
+                    new XAttribute("transform", $"translate(0 {options.SvgRect.Height.ToDisplayString()}) scale(1 -1)"),
                     new XComment(" this group handles display panning "),
                     new XElement(Xmlns + "g",
                         new XAttribute("transform", "translate(0 0)"),
@@ -78,7 +78,7 @@ namespace IxMilia.Converters
                             new XAttribute("class", "svg-scale"),
                             new XComment(" this group handles initial translation offset "),
                             new XElement(Xmlns + "g",
-                                new XAttribute("transform", $"translate({(-options.DxfSource.Left).ToDisplayString()} {(-options.DxfSource.Bottom).ToDisplayString()})"),
+                                new XAttribute("transform", $"translate({(-options.DxfRect.Left).ToDisplayString()} {(-options.DxfRect.Bottom).ToDisplayString()})"),
                                 world)))));
 
             var layerNames = file.Layers.OrderBy(l => l.Name).Select(l => l.Name).ToArray();

--- a/src/IxMilia.Converters/Spline2.cs
+++ b/src/IxMilia.Converters/Spline2.cs
@@ -22,7 +22,7 @@ namespace IxMilia.Converters
 
         public static bool operator ==(SplinePoint2 a, SplinePoint2 b)
         {
-            return a.X == b.X && a.Y == b.Y;
+            return a.X.IsCloseTo(b.X) && a.Y.IsCloseTo(b.Y);
         }
 
         public static bool operator !=(SplinePoint2 a, SplinePoint2 b)
@@ -43,8 +43,8 @@ namespace IxMilia.Converters
         public override bool Equals(object obj)
         {
             return obj is SplinePoint2 point &&
-                   X == point.X &&
-                   Y == point.Y;
+                   X.IsCloseTo(point.X) &&
+                   Y.IsCloseTo(point.Y);
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
* Unify naming
* Do not call ToArray for layerNames 
it's only used for Select, no need to copy to array
* Extract IsCloseTo to Double Extension
use it conveniently and everwhere
* Unify more naming
* Make Rects a class 
Since it's passed all around, we don't need copies. 
* Rename lambda variables 
for an open-source project names should be appropriate
* Rename DxfRect in ToPdf Converter
